### PR TITLE
Fix: Update Node.js version to 18.x for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "engines": {
+    "node": "18.x"
+  },
   "scripts": {
     "dev": "svelte-kit dev",
     "build": "svelte-kit build",


### PR DESCRIPTION
The Vercel build was failing due to an outdated Node.js version (16.x). This commit updates the `package.json` to specify Node.js 18.x by adding an "engines" field. This will ensure Vercel uses the correct Node.js version for builds.