### PR TITLE
Fix: Improve error handling for missing JWT_SECRET

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,6 +1,7 @@
 import * as env from '$env/dynamic/private';
 const JWT_SECRET = env.JWT_SECRET;
 import jwt from 'jsonwebtoken';
+import { error } from '@sveltejs/kit';
 
 /** @type {import('@sveltejs/kit').Handle} */
 export const handle = async ({ event, resolve }) => {
@@ -12,9 +13,10 @@ export const handle = async ({ event, resolve }) => {
       // Check if JWT_SECRET is loaded. It should be, but good practice to ensure.
       if (!JWT_SECRET) {
         console.error(
-          'JWT_SECRET is not available in hooks.server.js. Ensure it is set in .env and accessible via $env/static/private.'
+          'CRITICAL: JWT_SECRET is not available. This application cannot function securely without it.'
         );
-        // Depending on policy, might want to clear cookie or just proceed without auth
+        // Throw a 500 error to prevent further request processing and inform the user.
+        throw error(500, 'Server configuration error: JWT_SECRET is missing. Please set this environment variable in your deployment environment.');
       } else {
         const decoded = jwt.verify(token, JWT_SECRET);
         if (typeof decoded === 'object' && decoded !== null && 'id' in decoded) {


### PR DESCRIPTION
Previously, if the JWT_SECRET environment variable was not set, the application would proceed but could lead to unexpected errors further down the request lifecycle, often manifesting as generic 404 errors for all pages.

This change modifies `src/hooks.server.js` to:
- Import the `error` helper from `@sveltejs/kit`.
- Explicitly check for the presence of `JWT_SECRET`.
- If `JWT_SECRET` is missing, immediately throw a 500 server error with a clear message indicating that the secret needs to be configured in the deployment environment.

This makes the application more robust by failing fast and providing a clear diagnostic message when a critical piece of server configuration is missing, rather than silently failing or showing misleading 404 pages.