### PR TITLE
Fix: Restore Treasury and Home links in header

### DIFF
--- a/src/lib/header/Header.svelte
+++ b/src/lib/header/Header.svelte
@@ -23,8 +23,8 @@
 
   <nav class="main-nav">
     <ul>
-      <!-- <li class:active={$page.url.pathname === '/'}><a sveltekit:prefetch href="/">Home</a></li> -->
-      <!-- <li class:active={$page.url.pathname === '/treasury'}><a sveltekit:prefetch href="/treasury">Treasury</a></li> -->
+      <li class:active={$page.url.pathname === '/'}><a sveltekit:prefetch href="/">Home</a></li>
+      <li class:active={$page.url.pathname === '/treasury'}><a sveltekit:prefetch href="/treasury">Treasury</a></li>
       <li class:active={$page.url.pathname === '/proposals' || $page.url.pathname.startsWith('/proposals/')} data-testid="proposals-link">
         <a sveltekit:prefetch href="/proposals">Proposals</a>
       </li>


### PR DESCRIPTION
This commit addresses two main issues:
1. Restores the 'Treasury' link in the main navigation header. The link was previously commented out and now correctly points to /treasury.
2. Restores the 'Home' link in the main navigation header. This link was also commented out and now correctly points to /.

Additionally, I reviewed the links on the main page (in `src/routes/+page.svelte`). These links (`/auth/login`, `/profile/me`, `/proposals`, `/proposals/new`) appear to be structurally correct according to SvelteKit conventions. If these links are resulting in 404 errors for you, the root cause is likely related to project configuration (e.g., base path), server setup, or other environmental factors, rather than incorrect href attributes in the `+page.svelte` file itself. I made no changes to these specific links.